### PR TITLE
Extend angular schematics

### DIFF
--- a/collection.json
+++ b/collection.json
@@ -1,94 +1,58 @@
 {
+  "extends": "@schematics/angular",
   "schematics": {
     "action": {
-      "aliases": [ "a" ],
+      "aliases": [
+        "a"
+      ],
       "factory": "./src/action",
       "schema": "./src/action/schema.json",
       "description": "Add store actions"
     },
-
-    "class": {
-      "aliases": [ "cl" ],
-      "extends": "@schematics/angular:class"
-    },
-
-    "component": {
-      "aliases": [ "c" ],
-      "extends": "@schematics/angular:component"
-    },
-
     "container": {
-      "aliases": [ "co" ],
+      "aliases": [
+        "co"
+      ],
       "factory": "./src/container",
       "schema": "./src/container/schema.json",
       "description": "Add store container component"
     },
-
-    "directive": {
-      "aliases": [ "d" ],
-      "extends": "@schematics/angular:directive"
-    },
-
     "effect": {
-      "aliases": [ "ef" ],
+      "aliases": [
+        "ef"
+      ],
       "factory": "./src/effect",
       "schema": "./src/effect/schema.json",
       "description": "Add side effect class"
     },
-
     "entity": {
-      "aliases": [ "en" ],
+      "aliases": [
+        "en"
+      ],
       "factory": "./src/entity",
       "schema": "./src/entity/schema.json",
       "description": "Add entity state"
     },
-
-    "enum": {
-      "aliases": [ "e" ],
-      "extends": "@schematics/angular:enum"
-    },
-
     "feature": {
-      "aliases": [ "f" ],
+      "aliases": [
+        "f"
+      ],
       "factory": "./src/feature",
       "schema": "./src/feature/schema.json",
       "description": "Add feature state"
     },
-
-    "guard": {
-      "aliases": [ "g" ],
-      "extends": "@schematics/angular:guard"
-    },
-
-    "interface": {
-      "aliases": [ "i" ],
-      "extends": "@schematics/angular:interface"
-    },
-
-    "module": {
-      "aliases": [ "m" ],
-      "extends": "@schematics/angular:module"
-    },
-
-    "pipe": {
-      "aliases": [ "p" ],
-      "extends": "@schematics/angular:pipe"
-    },
-
     "reducer": {
-      "aliases": [ "r" ],
+      "aliases": [
+        "r"
+      ],
       "factory": "./src/reducer",
       "schema": "./src/reducer/schema.json",
       "description": "Add state reducer"
     },
-
-    "service": {
-      "aliases": [ "s" ],
-      "extends": "@schematics/angular:service"
-    },
-
     "store": {
-      "aliases": [ "st" ],
+      "aliases": [
+        "st"
+      ],
       "factory": "./src/store",
       "schema": "./src/store/schema.json",
       "description": "Adds initial setup for state managment"

--- a/collection.json
+++ b/collection.json
@@ -2,57 +2,49 @@
   "extends": "@schematics/angular",
   "schematics": {
     "action": {
-      "aliases": [
-        "a"
-      ],
+      "aliases": [ "a" ],
       "factory": "./src/action",
       "schema": "./src/action/schema.json",
       "description": "Add store actions"
     },
+
     "container": {
-      "aliases": [
-        "co"
-      ],
+      "aliases": [ "co" ],
       "factory": "./src/container",
       "schema": "./src/container/schema.json",
       "description": "Add store container component"
     },
+
     "effect": {
-      "aliases": [
-        "ef"
-      ],
+      "aliases": [ "ef" ],
       "factory": "./src/effect",
       "schema": "./src/effect/schema.json",
       "description": "Add side effect class"
     },
+
     "entity": {
-      "aliases": [
-        "en"
-      ],
+      "aliases": [ "en" ],
       "factory": "./src/entity",
       "schema": "./src/entity/schema.json",
       "description": "Add entity state"
     },
+
     "feature": {
-      "aliases": [
-        "f"
-      ],
+      "aliases": [ "f" ],
       "factory": "./src/feature",
       "schema": "./src/feature/schema.json",
       "description": "Add feature state"
     },
+
     "reducer": {
-      "aliases": [
-        "r"
-      ],
+      "aliases": [ "r" ],
       "factory": "./src/reducer",
       "schema": "./src/reducer/schema.json",
       "description": "Add state reducer"
     },
+
     "store": {
-      "aliases": [
-        "st"
-      ],
+      "aliases": [ "st" ],
       "factory": "./src/store",
       "schema": "./src/store/schema.json",
       "description": "Adds initial setup for state managment"


### PR DESCRIPTION
Using newer schematics `extends` ability to extend entire collection.